### PR TITLE
Add bg dark to the login and signup views

### DIFF
--- a/views/account/login/index.ejs
+++ b/views/account/login/index.ejs
@@ -7,7 +7,7 @@
     <script src="/account/login/main" type="module"></script>
   </head>
   <body
-    class="vh-100 bg-image"
+    class="vh-100 bg-image bg-dark"
     style="background-image: url('/gooncardbackground.jpg')"
   >
     <div class="mask d-flex align-items-center h-100 gradient-custom-3">

--- a/views/account/signup/index.ejs
+++ b/views/account/signup/index.ejs
@@ -7,7 +7,7 @@
     <title>Signup</title>
   </head>
   <body
-    class="vh-100 bg-image"
+    class="vh-100 bg-image bg-dark"
     style="background-image: url('/gooncardbackground.jpg')"
   >
     <div class="mask d-flex align-items-center h-100 gradient-custom-3">


### PR DESCRIPTION
WIP to fix issue #29 but you're gonna have to test it on your phone to see if it fixed the issue. 

On my side, I had fixed this problem in an earlier PR by making the body element store the background image since the image would resize based on the overall size of all the content. I made the change you suggested anyway but it's interesting because I can't re-test it locally. I even tried adding the login form to the webpage twice to bring it to a point where you had to scroll and it looks like it's working fine:
![image](https://user-images.githubusercontent.com/25871926/198569993-716cbb0d-ce43-4ad3-9c30-14dab90cf160.png)
![image](https://user-images.githubusercontent.com/25871926/198570016-9f6e3571-a621-4b86-be6e-4a1c1cff9e70.png)

Lemme know what ends up happening