### PR TITLE
Password encryption

### DIFF
--- a/db/seed.js
+++ b/db/seed.js
@@ -27,7 +27,7 @@ db.exec(sql, function (err) {
   if (err) throw err;
 });
 
-// Seed the database with some data
+// // Seed the database with some data
 console.log("Seeding database...");
 
 // Data to seed the database with

--- a/db/users.js
+++ b/db/users.js
@@ -1,5 +1,6 @@
 // Functions for manipulating the users table
 const knex = require("./knex");
+const bcrypt = require("bcrypt");
 const DEFAULT_SETTINGS = {
   theme: "light",
   fontSize: "12px",
@@ -19,13 +20,16 @@ const createUser = async (first_name, last_name, email, password) => {
     return [null];
   }
 
+  // Hash the password
+  let hashedPassword = bcrypt.hashSync(password, bcrypt.genSaltSync(10));
+
   return await knex("users")
     .insert(
       {
         first_name: first_name,
         last_name: last_name,
         email: email,
-        password: password,
+        password: hashedPassword,
         settings: JSON.stringify(DEFAULT_SETTINGS),
       },
       ["first_name", "last_name", "email", "password", "settings"]

--- a/db/users.js
+++ b/db/users.js
@@ -1,6 +1,7 @@
 // Functions for manipulating the users table
 const knex = require("./knex");
 const bcrypt = require("bcrypt");
+const SALT = 10;
 const DEFAULT_SETTINGS = {
   theme: "light",
   fontSize: "12px",
@@ -20,16 +21,13 @@ const createUser = async (first_name, last_name, email, password) => {
     return [null];
   }
 
-  // Hash the password
-  let hashedPassword = bcrypt.hashSync(password, bcrypt.genSaltSync(10));
-
   return await knex("users")
     .insert(
       {
         first_name: first_name,
         last_name: last_name,
         email: email,
-        password: hashedPassword,
+        password: bcrypt.hashSync(password, bcrypt.genSaltSync(SALT)),
         settings: JSON.stringify(DEFAULT_SETTINGS),
       },
       ["first_name", "last_name", "email", "password", "settings"]

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "address": "^1.2.1",
+    "bcrypt": "^5.1.0",
     "body-parser": "^1.20.1",
     "ejs": "^3.1.8",
     "express": "^4.18.2",

--- a/routes/login.js
+++ b/routes/login.js
@@ -48,7 +48,7 @@ module.exports = function (app, path) {
     // Get the user from the database
     const user = (await getUser(req.body.email))[0];
 
-    // If the user was found, check the hashed password
+    // If the user was found, make sure that their password matches (hashed)
     if (bcrypt.compareSync(req.body.password, user?.password)) {
       // Start the user's session and redirect them to the home page
       req.session.user = user;

--- a/routes/login.js
+++ b/routes/login.js
@@ -1,4 +1,5 @@
 const session = require("express-session");
+const bcrypt = require("bcrypt");
 const { getUser } = require("../db/users");
 
 module.exports = function (app, path) {
@@ -47,8 +48,8 @@ module.exports = function (app, path) {
     // Get the user from the database
     const user = (await getUser(req.body.email))[0];
 
-    // If the user was found, check the password
-    if (user?.password === req.body.password) {
+    // If the user was found, check the hashed password
+    if (bcrypt.compareSync(req.body.password, user?.password)) {
       // Start the user's session and redirect them to the home page
       req.session.user = user;
       res.redirect("/");


### PR DESCRIPTION
This PR adds encryption to passwords so that they aren't stored as plaintext in the database. It uses the bcrypt node module, so you will have to make sure to run `npm i` or the `npm run cleanStart` in order to download all dependencies.

This was tested with both the default seeded accounts as well as a newly created account, but the seeded accounts still have not changed from using 'password' as their password. Feel free to try making your own passwords without fearing them being seen in the database.