### PR TITLE
Add accounts endpoints

### DIFF
--- a/db/seed.js
+++ b/db/seed.js
@@ -6,6 +6,7 @@
 
 const fs = require("fs");
 const { createUser } = require("./users");
+const { createUserAccount } = require("./userAccounts");
 const sqlite3 = require("sqlite3").verbose();
 
 // Delete the old database if it exists
@@ -30,21 +31,34 @@ db.exec(sql, function (err) {
 // // Seed the database with some data
 console.log("Seeding database...");
 
-// Data to seed the database with
+// User data to seed the database with
 const promises = [
   createUser("John", "Doe", "johndoe@email.com", "password"),
   createUser("Jane", "Doe", "janedoe@email.com", "password"),
 ];
 
 // Wait for both promises to resolve
-Promise.all(promises)
-  .then(() => {
-    console.log("Done!");
-  })
-  .catch((err) => {
-    console.log(err);
-  })
-  .finally(() => {
-    db.close();
-    process.exit(0);
-  });
+Promise.all(promises).then(() => {
+  // User account data to seed the database with
+  const promises = [
+    createUserAccount("johndoe@email.com", "instagram", "@johndoe", 0),
+    createUserAccount("johndoe@email.com", "twitter", "@johndoe", 0),
+    createUserAccount("johndoe@email.com", "email", "johndoe@email.com", 1),
+    createUserAccount("janedoe@email.com", "instagram", "@janedoe", 0),
+    createUserAccount("janedoe@email.com", "twitter", "@janedoe", 0),
+    createUserAccount("janedoe@email.com", "email", "janedoe@email.com", 1),
+  ];
+
+  // Wait for all promises to resolve
+  Promise.all(promises)
+    .then(() => {
+      console.log("Done!");
+    })
+    .catch((err) => {
+      console.log(err);
+    })
+    .finally(() => {
+      db.close();
+      process.exit(0);
+    });
+});

--- a/db/userAccounts.js
+++ b/db/userAccounts.js
@@ -106,7 +106,25 @@ const updateUserAccount = async (userAccountId, label, value, type) => {
   )[0];
 };
 
-const deleteUserAccount = async (userAccountId) => {};
+/**
+ *
+ * Attempts to delete a user_account in the database.
+ *
+ * @param {number} userAccountId The ID of the user_account to delete.
+ * @returns {Promise<boolean>} Promise of true if the user_account was
+ * successfully deleted, or false if the user_account could not be deleted.
+ */
+const deleteUserAccount = async (userAccountId) => {
+  // Simply delete the user_account entry with the given ID.
+  return (
+    (await knex("user_accounts")
+      .where("id", userAccountId)
+      .del()
+      .catch((err) => {
+        console.log(err);
+      })) > 0
+  );
+};
 
 module.exports = {
   createUserAccount,

--- a/db/userAccounts.js
+++ b/db/userAccounts.js
@@ -16,7 +16,11 @@ const { getUser } = require("./users");
  */
 const createUserAccount = async (email, label, value, type) => {
   // Label and value must be non-empty strings, and type must be 0 or 1
-  if (label.length < 1 || value.length < 1 || (type !== "0" && type !== "1")) {
+  if (
+    label.length < 1 ||
+    value.length < 1 ||
+    (type !== "0" && type !== "1" && type !== 0 && type !== 1)
+  ) {
     return null;
   }
 
@@ -83,6 +87,27 @@ const getUserAccounts = async (email) => {
 
 /**
  *
+ * Attempts to find a user_account for a given user_account id.
+ *
+ * @param {number} userAccountId The ID of the user_account to get.
+ * @returns {Promise<object | null>} Promise of the user_account object if
+ * the user_account was successfully found, or null if the user_account
+ * could not be found.
+ */
+const getUserAccount = async (userAccountId) => {
+  // Find the user_account with the given ID.
+  const result = await knex("user_accounts")
+    .select("*")
+    .where("id", userAccountId)
+    .catch((err) => {
+      console.log(err);
+    });
+
+  return result && result[0] ? result[0] : null;
+};
+
+/**
+ *
  * Attempts to update a user_account in the database.
  *
  * @param {number} userAccountId The ID of the user_account to update.
@@ -134,6 +159,7 @@ const deleteUserAccount = async (userAccountId) => {
 module.exports = {
   createUserAccount,
   getUserAccounts,
+  getUserAccount,
   updateUserAccount,
   deleteUserAccount,
 };

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -99,7 +99,7 @@ module.exports = function (app, path) {
         req.body.id,
         req.body.label,
         req.body.value,
-        0
+        req.body.type
       );
     }
 

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -41,6 +41,13 @@ module.exports = function (app, path) {
   app.post("/account/profile/add", isLoggedIn, (req, res) => {});
 
   /**
+   * GET /account/profile/getall
+   *
+   * Gets all user_accounts for the current user.
+   */
+  app.get("/account/profile/getall", isLoggedIn, (req, res) => {});
+
+  /**
    * POST /account/profile/delete
    *
    * Deletes a user_account for the current user.

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -77,7 +77,6 @@ module.exports = function (app, path) {
     // Only perform the delete if the user_account belongs to the current user.
     let result = null;
     const accountToDelete = await getUserAccount(req.body.id);
-    console.log(accountToDelete);
     if (accountToDelete && accountToDelete.user_id === req.session.user.id) {
       result = await deleteUserAccount(req.body.id);
     }
@@ -91,5 +90,20 @@ module.exports = function (app, path) {
    *
    * Updates all user_accounts for the current user.
    */
-  app.post("/account/profile/update", isLoggedIn, (req, res) => {});
+  app.post("/account/profile/update", isLoggedIn, async (req, res) => {
+    // Only perform the update if the user_account belongs to the current user.
+    let result = null;
+    const accountToUpdate = await getUserAccount(req.body.id);
+    if (accountToUpdate && accountToUpdate.user_id === req.session.user.id) {
+      result = await updateUserAccount(
+        req.body.id,
+        req.body.label,
+        req.body.value,
+        0
+      );
+    }
+
+    // Respond with either the user_account object or null.
+    res.json(result);
+  });
 };

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -3,6 +3,7 @@ module.exports = function (app, path) {
   const {
     createUserAccount,
     getUserAccounts,
+    getUserAccount,
     updateUserAccount,
     deleteUserAccount,
   } = require("../db/userAccounts");
@@ -60,19 +61,35 @@ module.exports = function (app, path) {
    *
    * Gets all user_accounts for the current user.
    */
-  app.get("/account/profile/getall", isLoggedIn, (req, res) => {});
+  app.get("/account/profile/getall", isLoggedIn, async (req, res) => {
+    const result = await getUserAccounts(req.session.user.email);
+
+    // Respond with either the user_accounts array or null.
+    res.json(result);
+  });
 
   /**
    * POST /account/profile/delete
    *
    * Deletes a user_account for the current user.
    */
-  app.post("/account/profile/update", isLoggedIn, (req, res) => {});
+  app.post("/account/profile/delete", isLoggedIn, async (req, res) => {
+    // Only perform the delete if the user_account belongs to the current user.
+    let result = null;
+    const accountToDelete = await getUserAccount(req.body.id);
+    console.log(accountToDelete);
+    if (accountToDelete && accountToDelete.user_id === req.session.user.id) {
+      result = await deleteUserAccount(req.body.id);
+    }
+
+    // Respond with either the user_account object or null.
+    res.json(result);
+  });
 
   /**
    * POST /account/profile/update
    *
    * Updates all user_accounts for the current user.
    */
-  app.post("/account/profile/delete", isLoggedIn, (req, res) => {});
+  app.post("/account/profile/update", isLoggedIn, (req, res) => {});
 };

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -1,14 +1,6 @@
-const { getUser } = require("../db/users");
-
 module.exports = function (app, path) {
   // Middleware that redirects to login page if user is not logged in
   isLoggedIn = require("../util/middleware").isLoggedIn;
-  const {
-    getUserAccounts,
-    createUserAccount,
-    updateUserAccount,
-    deleteUserAccount,
-  } = require("../db/userAccounts");
 
   /**
    * GET /account/profile
@@ -39,9 +31,5 @@ module.exports = function (app, path) {
    */
   app.get("/account/profile/main", (req, res) => {
     res.sendFile(path + "/account/profile/main.js");
-  });
-
-  app.get("/test", isLoggedIn, async (req, res) => {
-    res.json(await updateUserAccount(2, "wrong", "false", 0));
   });
 };

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -1,6 +1,6 @@
 module.exports = function (app, path) {
   // Middleware that redirects to login page if user is not logged in
-  isLoggedIn = require("../util/middleware").isLoggedIn;
+  const isLoggedIn = require("../util/middleware").isLoggedIn;
 
   /**
    * GET /account/profile
@@ -32,4 +32,25 @@ module.exports = function (app, path) {
   app.get("/account/profile/main", (req, res) => {
     res.sendFile(path + "/account/profile/main.js");
   });
+
+  /**
+   * POST /account/profile/add
+   *
+   * Adds a new user_account for the current user.
+   */
+  app.post("/account/profile/add", isLoggedIn, (req, res) => {});
+
+  /**
+   * POST /account/profile/delete
+   *
+   * Deletes a user_account for the current user.
+   */
+  app.post("/account/profile/update", isLoggedIn, (req, res) => {});
+
+  /**
+   * POST /account/profile/update
+   *
+   * Updates all user_accounts for the current user.
+   */
+  app.post("/account/profile/delete", isLoggedIn, (req, res) => {});
 };

--- a/views/account/profile/index.ejs
+++ b/views/account/profile/index.ejs
@@ -24,7 +24,7 @@
                 <tr>
                   <th>Label</th>
                   <th>Value</th>
-                  <th></th>
+                  <th colspan="2">Actions</th>
                 </tr>
               </thead>
               <tbody id="accounts-table-body"></tbody>

--- a/views/account/profile/style.css
+++ b/views/account/profile/style.css
@@ -37,6 +37,7 @@ input {
   display: inline-block;
 }
 
-button#add-new-type {
+button#add-new-type,
+button.update {
   width: 14ch;
 }

--- a/views/account/profile/style.css
+++ b/views/account/profile/style.css
@@ -38,5 +38,5 @@ input {
 }
 
 button#add-new-type {
-  width: 12ch;
+  width: 14ch;
 }


### PR DESCRIPTION
Closes #39 and #68.

This PR implements all of the needed API endpoints for manipulating `user_account` entries in the database. An endpoint for each of the following actions has been set up:

- Adding a new user_account (expecting a label, value, and type).
- Updating a new user_account (expecting a label, value, and type).
- Deleting an existing user_account (expecting an id).
- Getting all user_account entries for a user (expecting an email).

Additionally, the Profile page is fully functional. The user is able to add a new account, edit individual fields of an existing account, as well as delete an existing account. If a user tries editing an account with a label or value that is blank, the previous value will be restored to the text input.

I know that Nisha recently added account types to this page in her PR #81, so there will need to be a merge at some point. I just have buttons that toggle, she has switches: I don't mind what gets used, but I just made something simple here so that I could actually connect the front and back ends together. I would recommend merging this PR first, since there it includes a lot of the functionality for actually modifying the database. Once this PR is in, we can merge Nisha's changes to make sure that they don't conflict with any of the working functionality.

I recommend you try running this for yourself to test the functionality on your own machines.