### PR TITLE
Fixes registration bug by getting the user's id on registration.

### DIFF
--- a/db/users.js
+++ b/db/users.js
@@ -33,7 +33,7 @@ const createUser = async (first_name, last_name, email, password) => {
         password: bcrypt.hashSync(password, bcrypt.genSaltSync(SALT)),
         settings: JSON.stringify(require("./defaultSettings")),
       },
-      ["first_name", "last_name", "email", "password", "settings"]
+      ["id", "first_name", "last_name", "email", "password", "settings"]
     )
     .catch((err) => {
       console.log(err);


### PR DESCRIPTION
Closes #95, fixed version of PR #104.

When the user registers for a Goon Card account, they are redirected to the profile page to begin adding linked profiles. A user could add accounts just fine, but they would get errors when they tried editing or deleting them. This was because the user's session did not contain their id when they signed up for Goon Card; signing in was never a problem.