### PR TITLE
Add settings buttons

### DIFF
--- a/db/defaultSettings.json
+++ b/db/defaultSettings.json
@@ -1,6 +1,6 @@
 {
   "font_size": "medium",
-  "font_family": "Times New Roman",
+  "font_family": "Arial",
   "contrast": "Low",
   "theme": "Light Theme"
 }

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -74,7 +74,8 @@ module.exports = function (app, path) {
 
     // Otherwise, redirect to the settings page with an error message.
     else {
-      req.session.error = "There was an error updating your settings.";
+      req.session.error =
+        "There was an error updating one or more of your settings.";
       res.redirect("/account/settings");
     }
   });

--- a/views/account/settings/index.ejs
+++ b/views/account/settings/index.ejs
@@ -131,7 +131,7 @@
             </div>
           </div>
           <br />
-          <div>
+          <div class="mb-3">
             <button
               id="cancel-changes"
               type="button"

--- a/views/account/settings/index.ejs
+++ b/views/account/settings/index.ejs
@@ -144,6 +144,7 @@
               id="save-changes"
               type="submit"
               class="btn btn-warning inline-block-child"
+              disabled
             >
               Save Changes
             </button>

--- a/views/account/settings/index.ejs
+++ b/views/account/settings/index.ejs
@@ -132,7 +132,21 @@
           </div>
           <br />
           <div>
-            <button class="button submit" id="submit" disabled>Submit</button>
+            <button
+              id="cancel-changes"
+              type="button"
+              class="btn btn-light inline-block-child"
+              disabled
+            >
+              Cancel Changes
+            </button>
+            <button
+              id="save-changes"
+              type="submit"
+              class="btn btn-warning inline-block-child"
+            >
+              Save Changes
+            </button>
           </div>
         </form>
       </div>

--- a/views/account/settings/index.ejs
+++ b/views/account/settings/index.ejs
@@ -17,7 +17,7 @@
           <% if (error) { %>
           <p class="message text-danger"><%= error %></p>
           <% } else if(success) { %>
-          <p class="message text-success"><%= success %></p>
+          <p class="message text-warning"><%= success %></p>
           <% } %>
         </div>
 

--- a/views/account/settings/main.js
+++ b/views/account/settings/main.js
@@ -42,24 +42,23 @@ options.theme.forEach((option) => {
   selectTheme.appendChild(optionElement);
 });
 
+// Store references to useful input fields.
 let save_changes = document.getElementById("save-changes");
 let cancel_changes = document.getElementById("cancel-changes");
-
-// Set the correct checked radio button for the contrast option.
 let highContrast = document.getElementById("highContrast");
 let lowContrast = document.getElementById("lowContrast");
-if (settings.contrast === "High") {
-  highContrast.checked = true;
-} else {
-  lowContrast.checked = true;
-}
 
-// Set the default settings in the DOM.
+// Set and store the default settings in the DOM.
 let originalFirstName = document.getElementById("editFirstName").value;
 let originalLastName = document.getElementById("editLastName").value;
 document.getElementById("editFontSize").value = settings.font_size;
 document.getElementById("editFontFamily").value = settings.font_family;
 document.getElementById("editTheme").value = settings.theme;
+if (settings.contrast === "High") {
+  highContrast.checked = true;
+} else {
+  lowContrast.checked = true;
+}
 
 /**
  * Function to be run whenever any user input is detected. This method ensures
@@ -98,6 +97,20 @@ const updateFormButtons = () => {
   // Set the state of the buttons accordingly.
   save_changes.disabled = submitDisabled;
   cancel_changes.disabled = cancelDisabled;
+};
+
+/**
+ * When the user clicks on the cancel button, the page is reloaded after confirmation
+ * in order to reset the user's account changes since the last save.
+ */
+cancel_changes.onclick = () => {
+  if (
+    confirm(
+      "Are you sure you want to cancel? All changes since your last save will be lost."
+    )
+  ) {
+    location.reload();
+  }
 };
 
 // Add event listeners to the input fields.

--- a/views/account/settings/main.js
+++ b/views/account/settings/main.js
@@ -42,6 +42,9 @@ options.theme.forEach((option) => {
   selectTheme.appendChild(optionElement);
 });
 
+let save_changes = document.getElementById("save-changes");
+let cancel_changes = document.getElementById("cancel-changes");
+
 // Set the correct checked radio button for the contrast option.
 let highContrast = document.getElementById("highContrast");
 let lowContrast = document.getElementById("lowContrast");
@@ -52,30 +55,56 @@ if (settings.contrast === "High") {
 }
 
 // Set the default settings in the DOM.
+let originalFirstName = document.getElementById("editFirstName").value;
+let originalLastName = document.getElementById("editLastName").value;
 document.getElementById("editFontSize").value = settings.font_size;
 document.getElementById("editFontFamily").value = settings.font_family;
 document.getElementById("editTheme").value = settings.theme;
 
-// Determine if the user can save their settings.
-const canSubmit = () => {
-  // Get the values of the first and last name fields
+/**
+ * Function to be run whenever any user input is detected. This method ensures
+ * that all buttons on the page are either enabled or disabled as appropriate.
+ */
+const updateFormButtons = () => {
+  // Default status of the buttons.
+  let submitDisabled = true;
+  let cancelDisabled = true;
+
+  // If any of the input fields have changed, enable both buttons.
+  if (
+    document.getElementById("editFirstName").value !== originalFirstName ||
+    document.getElementById("editLastName").value !== originalLastName ||
+    document.getElementById("editFontSize").value !== settings.font_size ||
+    document.getElementById("editFontFamily").value !== settings.font_family ||
+    document.getElementById("editTheme").value !== settings.theme ||
+    document.getElementById("highContrast").checked !==
+      (settings.contrast === "High")
+  ) {
+    submitDisabled = false;
+    cancelDisabled = false;
+  } else {
+    // If the input fields have not changed, disable the submit and cancel buttons.
+    submitDisabled = true;
+    cancelDisabled = true;
+  }
+
+  // If any text boxes are empty, disable the submit button.
   var firstName = document.getElementById("editFirstName").value;
   var lastName = document.getElementById("editLastName").value;
-
-  // First and last name must be at least 1 character long
-  return firstName.length > 0 && lastName.length > 0;
-};
-
-const checkSubmit = () => {
-  if (canSubmit()) {
-    document.getElementById("save-changes").disabled = false;
-  } else {
-    document.getElementById("save-changes").disabled = true;
+  if (firstName === "" || lastName === "") {
+    submitDisabled = true;
   }
+
+  // Set the state of the buttons accordingly.
+  save_changes.disabled = submitDisabled;
+  cancel_changes.disabled = cancelDisabled;
 };
 
-// Should check if the user can log in when the document loads
-checkSubmit();
-
-// Add a keyup event listener for the document
-document.addEventListener("keyup", checkSubmit);
+// Add event listeners to the input fields.
+document.getElementById("editFirstName").oninput = updateFormButtons;
+document.getElementById("editLastName").oninput = updateFormButtons;
+document.getElementById("editFontSize").onchange = updateFormButtons;
+document.getElementById("editFontFamily").onchange = updateFormButtons;
+document.getElementById("editTheme").onchange = updateFormButtons;
+document.getElementById("highContrast").onchange = updateFormButtons;
+document.getElementById("lowContrast").onchange = updateFormButtons;

--- a/views/account/settings/main.js
+++ b/views/account/settings/main.js
@@ -68,9 +68,9 @@ const canSubmit = () => {
 
 const checkSubmit = () => {
   if (canSubmit()) {
-    document.getElementById("submit").disabled = false;
+    document.getElementById("save-changes").disabled = false;
   } else {
-    document.getElementById("submit").disabled = true;
+    document.getElementById("save-changes").disabled = true;
   }
 };
 


### PR DESCRIPTION
Closes #115.

The settings page now has cancel and submit buttons that perform just like those on the profile page. This improves consistency in our application and helps make things look a bit more uniform. The submit and cancel buttons are only enabled when there are changes to the input (resetting input to original values disables them again). Additionally, empty text boxes will _also_ disable the submit button. Users are presented with the same confirmation screen when they want to clear their input, and are prompted with a success message if input is successfully modified.