### PR TITLE
No account text

### DIFF
--- a/views/account/profile/index.ejs
+++ b/views/account/profile/index.ejs
@@ -30,7 +30,7 @@
             <h1 id="edit-existing-header">Edit Existing</h1>
 
             <table id="accounts-table" class="table table-borderless">
-              <thead>
+              <thead id="table-head">
                 <tr>
                   <th>Platform</th>
                   <th>Account</th>

--- a/views/account/profile/main.js
+++ b/views/account/profile/main.js
@@ -40,6 +40,8 @@ const labels = [];
 const values = [];
 const types = [];
 const ids = [];
+
+// If the user has at least one account, display the main content normally.
 if (user_accounts) {
   user_accounts.forEach((account) => {
     labels.push(account.label);
@@ -98,6 +100,29 @@ const updateFormButtons = () => {
   save_changes.disabled = submitDisabled;
   cancel_changes.disabled = cancelDisabled;
   add_new_account_submit.disabled = addDisabled;
+};
+
+// If the user has no accounts, clear the table's headings.
+const updateTableHeading = () => {
+  // The current account total is the original minus the number of accounts
+  // that have been deleted plus the number of accounts that have been added.
+  const count = labels.length - remove.length + add.length;
+
+  // If the user has no accounts, clear the table's headings.
+  if (count == 0) {
+    document.getElementById("table-head").innerHTML = "";
+    document.getElementById("edit-existing-header").style.display = "none";
+  } else {
+    document.getElementById("table-head").innerHTML = `
+      <tr>
+        <th>Platform</th>
+        <th>Account</th>
+        <th>Professional</th>
+        <th>Delete</th>
+      </tr>
+    `;
+    document.getElementById("edit-existing-header").style.display = "block";
+  }
 };
 
 /**
@@ -223,6 +248,7 @@ function add_row(table, label, value, type, id) {
       // Finally, remove the row from the table.
       table.removeChild(tr);
       updateFormButtons();
+      updateTableHeading();
     }
   };
 
@@ -264,6 +290,7 @@ add_new_account_submit.onclick = () => {
   add_new_type.value = "";
 
   updateFormButtons();
+  updateTableHeading();
 };
 
 /**
@@ -320,3 +347,4 @@ add_new_type.onchange = () => updateFormButtons();
 
 // Populate the table with the user's accounts.
 populate_table();
+updateTableHeading();

--- a/views/home/index.ejs
+++ b/views/home/index.ejs
@@ -13,7 +13,7 @@
         class="cover-container h-100 w-100 align-items-center p-3 mx-auto mt-3"
       >
         <div class="row col-12 mt-3">
-          <main class="px-3">
+          <main class="px-3" id="main-content">
             <!--These buttons are to autmatically toggle all the switches for the user-->
             <button class="btn btn-warning btn-lg" type="button">Casual</button>
             <button class="btn btn-warning btn-lg" type="button">

--- a/views/home/main.js
+++ b/views/home/main.js
@@ -44,7 +44,7 @@ else {
     <div class="container">
       <div class="row">
         <div class="col-12">
-          <h1 class="text-center">You have no accounts!</h1>
+          <h3 class="text-center">You have no accounts!</h3>
           <p class="text-center">Click <a href="/account/profile">here</a> to add an account.</p>
         </div>
       </div>

--- a/views/home/main.js
+++ b/views/home/main.js
@@ -2,6 +2,7 @@ let toggles_div = document.getElementById("toggles-div");
 let qrcode_div = document.getElementById("qrcode-div");
 let qrcode_submit = document.getElementById("qr_submit");
 let size = document.getElementById("size");
+let main = document.getElementById("main-content");
 
 // Fetch the user_accounts from the database.
 let user_accounts = await (
@@ -25,6 +26,8 @@ let labels = [];
 let values = [];
 let types = [];
 let ids = [];
+
+// If the user has at least one account, display the main content normally.
 if (user_accounts) {
   user_accounts.forEach((account) => {
     labels.push(account.label);
@@ -32,6 +35,22 @@ if (user_accounts) {
     types.push(account.type);
     ids.push(account.id);
   });
+  main.style.display = "block";
+}
+
+// If the user does not have any accounts, replace main content with a message.
+else {
+  document.getElementById("main-content").innerHTML = `
+    <div class="container">
+      <div class="row">
+        <div class="col-12">
+          <h1 class="text-center">You have no accounts!</h1>
+          <p class="text-center">Click <a href="/account/profile">here</a> to add an account.</p>
+        </div>
+      </div>
+    </div>
+  `;
+  main.style.display = "block";
 }
 
 // Need to maintain the checked state of the toggle buttons.

--- a/views/home/main.js
+++ b/views/home/main.js
@@ -41,11 +41,11 @@ if (user_accounts) {
 // If the user does not have any accounts, replace main content with a message.
 else {
   document.getElementById("main-content").innerHTML = `
-    <div class="container">
-      <div class="row">
+    <div class="container p-5 mt-5">
+      <div class="row p-5 mt-5">
         <div class="col-12">
-          <h3 class="text-center">You have no accounts!</h3>
-          <p class="text-center">Click <a href="/account/profile">here</a> to add an account.</p>
+          <h2 class="text-center">You have no accounts!</h3>
+          <h3 class="text-center">Click <a class="text-warning" href="/account/profile">here</a> to add an account.</h3>
         </div>
       </div>
     </div>

--- a/views/home/style.css
+++ b/views/home/style.css
@@ -30,3 +30,7 @@
   border-radius: 5rem;
   float: none;
 }
+
+main#main-content {
+  display: none;
+}


### PR DESCRIPTION
Closes #112.

Custom text is added on the home screen and table headings are removed on the profiles page for when a user does not have any accounts. Note that the current changes just implement the text itself; what the text says and the formatting of it is still up in the air so feel free to comment what you think and/or push your own commits to this PR that update the text.