### PR TITLE
Add qrcode endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "express": "^4.18.2",
     "express-session": "^1.17.3",
     "knex": "^2.3.0",
-    "sqlite3": "^5.1.2"
+    "sqlite3": "^5.1.2",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.20",

--- a/routes/displaycard.js
+++ b/routes/displaycard.js
@@ -7,7 +7,9 @@ module.exports = function (app, path) {
    */
   app.get("/displaycard", (req, res) => {
     // Pass the user object to the displaycard page
-    res.render(path + "/displaycard/index");
+    res.render(path + "/displaycard/index", {
+      uuid: req.query.id,
+    });
   });
 
   /**

--- a/routes/home.js
+++ b/routes/home.js
@@ -68,7 +68,9 @@ module.exports = function (app, path) {
       // Generate a UUID.
       uuid = uuidv4();
 
-      // TODO Try and find this UUID in the database.
+      /**
+       * TODO: Check if the UUID already exists in the database.
+       */
       const hardCoded = false;
 
       // If the UUID does not exist in the database, use it
@@ -79,7 +81,9 @@ module.exports = function (app, path) {
 
     // Use the UUID to create new card_entries in the database.
     submittedIds.forEach((id) => {
-      // TODO Create a new card_entry in the database with id and uuid.
+      /**
+       * TODO: Create a new card_entry in the database.
+       */
     });
 
     // Finally, return the UUID.

--- a/routes/home.js
+++ b/routes/home.js
@@ -1,4 +1,4 @@
-module.exports = function (app, path) {
+module.exports = function (app, path, address, port) {
   // Middleware that redirects to login page if user is not logged in
   const isLoggedIn = require("../util/middleware").isLoggedIn;
   const { getUserAccounts } = require("../db/userAccounts");
@@ -34,6 +34,15 @@ module.exports = function (app, path) {
    */
   app.get("/home/main", (req, res) => {
     res.sendFile(path + "/home/main.js");
+  });
+
+  /**
+   * GET /home/siteaddress
+   *
+   * Returns the address of the server.
+   */
+  app.get("/home/siteaddress", (req, res) => {
+    res.json(`${address}:${port}`);
   });
 
   /**

--- a/routes/home.js
+++ b/routes/home.js
@@ -2,6 +2,7 @@ module.exports = function (app, path) {
   // Middleware that redirects to login page if user is not logged in
   const isLoggedIn = require("../util/middleware").isLoggedIn;
   const { getUserAccounts } = require("../db/userAccounts");
+  const { v4: uuidv4 } = require("uuid");
 
   /**
    * GET /
@@ -46,17 +47,42 @@ module.exports = function (app, path) {
       (account) => account.id
     );
 
-    // If the user has no user_accounts, return an error.
-    if (ids.length === 0) {
+    // If the user has no user_accounts or no submitted ids, return an error.
+    const submittedIds = req.body.ids;
+    if (ids.length === 0 || submittedIds.length === 0) {
       res.json(null);
       return;
     }
 
     // Make sure that each id in the body is an account id for the user.
-    const valid = req.body.ids.every((id) => ids.includes(id));
+    const valid = submittedIds.every((id) => ids.includes(id));
     if (!valid) {
       res.json(null);
       return;
     }
+
+    // Generate a UUID and make sure it does not already exist in the database.
+    let generated = false;
+    let uuid = null;
+    while (!generated) {
+      // Generate a UUID.
+      uuid = uuidv4();
+
+      // TODO Try and find this UUID in the database.
+      const hardCoded = false;
+
+      // If the UUID does not exist in the database, use it
+      if (!hardCoded) {
+        generated = true;
+      }
+    }
+
+    // Use the UUID to create new card_entries in the database.
+    submittedIds.forEach((id) => {
+      // TODO Create a new card_entry in the database with id and uuid.
+    });
+
+    // Finally, return the UUID.
+    res.json(uuid);
   });
 };

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const bodyParser = require("body-parser");
 
 // Create backend constants
 const app = express();
+const siteAddress = address.ip();
 const port = 3000;
 const viewsPath = __dirname + "/views";
 const sessionKey = "secret";
@@ -34,7 +35,7 @@ app.use(
 );
 
 // Import all routes from their respective files
-require("./routes/home")(app, viewsPath);
+require("./routes/home")(app, viewsPath, siteAddress, port);
 require("./routes/login")(app, viewsPath);
 require("./routes/logout")(app, viewsPath);
 require("./routes/signup")(app, viewsPath);
@@ -51,5 +52,5 @@ app.get("*", (req, res) => {
 
 // Start the server
 app.listen(port, () =>
-  console.log(`Access the server at http://${address.ip()}:${port}`)
+  console.log(`Access the server at http://${siteAddress}:${port}`)
 );

--- a/views/displaycard/index.ejs
+++ b/views/displaycard/index.ejs
@@ -11,14 +11,19 @@
       <div
         class="cover-container h-100 w-100 align-items-center p-3 mx-auto mt-3"
       >
-          <main class="px-3">
-            <h1 id="profile-owner-name"></h1>
-            <!-- This creates a divider to indicate the jump from the header to the actual content -->
-            <hr />
-            <div id="profile-contents">
-            </div>
-            <p id="interested-message">Interested in your own GOON card? <a class="text-warning" href="/views/account/signup/">Sign up here</a></p>
-          </main>
+        <%= `TEST: UUID for this card is ${uuid}` %>
+        <main class="px-3">
+          <h1 id="profile-owner-name"></h1>
+          <!-- This creates a divider to indicate the jump from the header to the actual content -->
+          <hr />
+          <div id="profile-contents"></div>
+          <p id="interested-message">
+            Interested in your own GOON card?
+            <a class="text-warning" href="/views/account/signup/"
+              >Sign up here</a
+            >
+          </p>
+        </main>
       </div>
       <%- include('../partials/footer'); %>
     </div>

--- a/views/home/index.ejs
+++ b/views/home/index.ejs
@@ -35,14 +35,15 @@
                 <option value="200x200" selected>200x200</option>
                 <option value="300x300">300x300</option>
               </select>
-              <a
-                id="qr_submit"
-                href="#"
+              <button
+                id="qr-submit"
                 class="btn btn-warning btn-lg"
                 role="button"
                 aria-disabled="true"
-                >Generate</a
+                disabled
               >
+                Generate
+              </button>
             </form>
             <br />
             <div id="qrcode-div" class="m-auto"></div>

--- a/views/home/main.js
+++ b/views/home/main.js
@@ -87,20 +87,19 @@ let onGenerateSubmit = async function (e) {
       body: JSON.stringify({ ids: toggles }),
     })
   ).json();
-  console.log(uuid);
 
+  // Get the address of the server.
   const siteAddress = await (
     await fetch("/home/siteaddress", {
       method: "GET",
     })
   ).json();
-  console.log(siteAddress);
 
   // Clear the div's contents
   qrcode_div.innerHTML = "";
 
-  // Create the QR code using the google charts api
-  let url = `http://${siteAddress}/home/generate?${uuid}`;
+  // Create the QR code using the google charts api and the uuid.
+  const url = `http://${siteAddress}/displaycard?id=${uuid}`;
   let qrcode = document.createElement("img");
   let qrcode_url = new URL("https://chart.googleapis.com/chart?");
   qrcode_url.searchParams.append("chs", size.value);
@@ -112,6 +111,9 @@ let onGenerateSubmit = async function (e) {
 
   // Append the QR Code inside the qrcode div
   qrcode_div.appendChild(qrcode);
+
+  console.log(url);
+  alert(url);
 };
 
 qrcode_submit.onclick = onGenerateSubmit;

--- a/views/home/main.js
+++ b/views/home/main.js
@@ -1,6 +1,6 @@
 let toggles_div = document.getElementById("toggles-div");
 let qrcode_div = document.getElementById("qrcode-div");
-let qrcode_submit = document.getElementById("qr_submit");
+let qrcode_submit = document.getElementById("qr-submit");
 let size = document.getElementById("size");
 
 // Fetch the user_accounts from the database.
@@ -57,7 +57,13 @@ for (let i = 0; i < labels.length; i++) {
     } else {
       toggles = toggles.filter((id) => id != parseInt(this.id));
     }
-    console.log(toggles);
+
+    // See if the submit button should be enabled.
+    if (toggles.length === 0) {
+      qrcode_submit.disabled = true;
+    } else {
+      qrcode_submit.disabled = false;
+    }
   };
 
   let toggle_label = document.createElement("label");

--- a/views/home/main.js
+++ b/views/home/main.js
@@ -53,9 +53,9 @@ for (let i = 0; i < labels.length; i++) {
    */
   toggle.onchange = function () {
     if (this.checked) {
-      toggles.push(this.id);
+      toggles.push(parseInt(this.id));
     } else {
-      toggles = toggles.filter((id) => id != this.id);
+      toggles = toggles.filter((id) => id != parseInt(this.id));
     }
     console.log(toggles);
   };
@@ -77,14 +77,30 @@ for (let i = 0; i < labels.length; i++) {
 let onGenerateSubmit = async function (e) {
   e.preventDefault();
 
-  // CALL THE GENERATE QR CODE API ENDPOINT WITH TOGGLES ARRAY
-  // DISPLAY THE RESPONDED QR CODE IMAGE
+  // Call the /home/generate endpoint with the toggles array.
+  const uuid = await (
+    await fetch("/home/generate", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ ids: toggles }),
+    })
+  ).json();
+  console.log(uuid);
+
+  const siteAddress = await (
+    await fetch("/home/siteaddress", {
+      method: "GET",
+    })
+  ).json();
+  console.log(siteAddress);
 
   // Clear the div's contents
   qrcode_div.innerHTML = "";
 
   // Create the QR code using the google charts api
-  let url = "You toggled the following accounts: " + toggles.join(", ");
+  let url = `http://${siteAddress}/home/generate?${uuid}`;
   let qrcode = document.createElement("img");
   let qrcode_url = new URL("https://chart.googleapis.com/chart?");
   qrcode_url.searchParams.append("chs", size.value);

--- a/views/home/main.js
+++ b/views/home/main.js
@@ -56,6 +56,15 @@ else {
   main.style.display = "block";
 }
 
+// See if the submit button should be enabled.
+function check_toggles(num_toggles) {
+  if (num_toggles === 0) {
+    qrcode_submit.disabled = true;
+  } else {
+    qrcode_submit.disabled = false;
+  }
+}
+
 // Need to maintain the checked state of the toggle buttons.
 let toggles = [];
 let toggle_switch_elements = [];
@@ -84,13 +93,8 @@ for (let i = 0; i < labels.length; i++) {
       toggles = toggles.filter((id) => id != parseInt(this.id));
       num_toggled_elements -= 1;
     }
-
-    // See if the submit button should be enabled.
-    if (toggles.length === 0) {
-      qrcode_submit.disabled = true;
-    } else {
-      qrcode_submit.disabled = false;
-    }
+    
+    check_toggles(toggles.length)
   };
 
   let toggle_label = document.createElement("label");
@@ -143,6 +147,9 @@ all_btn.onclick = function () {
   } else {
     turn_all_switches_on();
   }
+
+  check_toggles(num_toggled_elements)
+
 };
 
 /**

--- a/views/home/main.js
+++ b/views/home/main.js
@@ -93,8 +93,8 @@ for (let i = 0; i < labels.length; i++) {
       toggles = toggles.filter((id) => id != parseInt(this.id));
       num_toggled_elements -= 1;
     }
-    
-    check_toggles(toggles.length)
+
+    check_toggles(toggles.length);
   };
 
   let toggle_label = document.createElement("label");
@@ -148,8 +148,7 @@ all_btn.onclick = function () {
     turn_all_switches_on();
   }
 
-  check_toggles(num_toggled_elements)
-
+  check_toggles(num_toggled_elements);
 };
 
 /**


### PR DESCRIPTION
Closes #1, closes #40.

This PR uses the new `card_entries` table to add entries anytime the user clicks 'generate' on the home screen. The backend API is called, a unique UUID for that card is generated and stored in the database, and the UUID is returned to the client. The QR code can then be generated with this ID, and the user can navigate to the card page. Currently, the accounts are not showing up on the page, but this is a task for issue #113.

When generating a QR code, an alert pops up with the URL (also logged to the console) which is useful now for testing since not everyone's phone is working with the application. You can just copy and paste this into your browser on your computer to test the link.

I definitely recommend testing this one out on your own computers.