### PR TITLE
Fix displaycard

### DIFF
--- a/views/displaycard/index.ejs
+++ b/views/displaycard/index.ejs
@@ -23,8 +23,7 @@
           </p>
         </main>
       </div>
-      <%- include('../partials/footer'); %> <%-
-      include('../partials/defaultSettings', {user: user}) %>
+      <%- include('../partials/footer'); %> 
     </div>
   </body>
 </html>

--- a/views/displaycard/index.ejs
+++ b/views/displaycard/index.ejs
@@ -7,6 +7,8 @@
     <title>Business Card</title>
   </head>
   <body id="body" class="h-100 text-center text-white dark-mode bg-dark">
+
+    <% var user = undefined; %>
     <div id="page-container">
       <div
         class="cover-container h-100 w-100 align-items-center p-3 mx-auto mt-3"
@@ -23,7 +25,10 @@
           </p>
         </main>
       </div>
-      <%- include('../partials/footer'); %> 
+      <%- include('../partials/footer'); %>
+      <% if (typeof user === 'undefined') { %>
+      <%- include('../partials/defaultSettings', {user: user}) %> 
+      <% } %>
     </div>
   </body>
 </html>


### PR DESCRIPTION
Closes #139 

When trying to navigate to the display card page after a lot of the changes we've made, there is an "undefined user error" being thrown. This fixes that error by temporarily passing an undefined user variable and optionally including the defaultSettings file depending on whether a user is currently available.

This should be fixed later, but this is just so that we can actually view the page for the time being.