### PR TITLE
Adds changes necessary for cascading deletions.

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -14,7 +14,7 @@ CREATE TABLE "user_accounts" (
 	"label"	TEXT NOT NULL,
 	"value"	TEXT NOT NULL,
 	"type"	INTEGER NOT NULL,
-	FOREIGN KEY("user_id") REFERENCES "users"("id"),
+	FOREIGN KEY("user_id") REFERENCES "users"("id")  ON DELETE CASCADE,
 	PRIMARY KEY("id" AUTOINCREMENT)
 );
 
@@ -22,6 +22,6 @@ CREATE TABLE "card_entries" (
 	"id"	INTEGER NOT NULL UNIQUE,
 	"uuid"	TEXT NOT NULL,
 	"user_account_id"	INTEGER NOT NULL,
-	FOREIGN KEY("user_account_id") REFERENCES "user_accounts"("id"),
+	FOREIGN KEY("user_account_id") REFERENCES "user_accounts"("id") ON DELETE CASCADE,
 	PRIMARY KEY("id" AUTOINCREMENT)
 );

--- a/db/userAccounts.js
+++ b/db/userAccounts.js
@@ -154,6 +154,9 @@ const updateUserAccount = async (userAccountId, label, value, type) => {
  * successfully deleted, or false if the user_account could not be deleted.
  */
 const deleteUserAccount = async (userAccountId) => {
+  // This line enables the foreign key constraint to cascade deletions.
+  await knex.raw("PRAGMA foreign_keys = ON");
+
   // Simply delete the user_account entry with the given ID.
   return (
     (await knex("user_accounts")


### PR DESCRIPTION
This is a necessary change before working on issue #65. <hr>

Adds cascade delete to both user_accounts and card_entries, meaning:
- If a user deletes their account, all of their `user_accounts` and `card_entries` will also be deleted. Note that this functionality is not implemented, but now can be in #65.
- If a user deletes a `user_account`, any `card_entries` that once included that account will now be deleted. This means that if I share my Instagram and Twitter accounts together, deleting my Instagram account will now result in that QR code only showing Twitter. <hr>

Adds a single line of raw SQL that needs to be executed before deleting a `user_account` or a `user` object that allows the cascades to work correctly.
- Currently only implemented in deleting `user_account`s, but will be needed when the user can delete their entire Goon Card account.