### PR TITLE
Adds the 'start-vm' and 'cleanStart-vm' script variations for the cluster VM.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,14 @@ We are using an SQLite database in order to store users' preferred settings as w
 
 ## -- Development Process --
 
-We currently have 4 commands:
+We currently have 6 development scripts:
 
 1. `npm run format` - Formats the application code usually the Prettier Formatting
 2. `npm run seed` - Loads the database with default values
 3. `npm start` - Starts up the server so that you can use the application, and runs `npm run format`
 4. `npm run cleanStart` - Runs a combination of the first 3 commands in the order listed.
+5. `npm run start-vm` - Runs the server on the TCNJ VM with the appropriate gooncard.hpc.tcnj.edu web address.
+6. `npm run cleanStart-vm` - Runs a combination of the first 3 commands in the order listed, but again, specifically for the VM.
 
 When you make a change (At least on the front-end side), you should just be able to refresh the page. Before you push the code to the repo to make a Pull Request, make sure to run `npm run format` to format the code so that it matches the repo's white space and indentation.
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "format": "prettier --write ./",
     "seed": "node ./db/seed.js",
     "start": "npm run format && nodemon server.js",
-    "cleanStart": "rm -rf ./node_modules && npm install && npm run seed && npm start"
+    "cleanStart": "rm -rf ./node_modules && npm install && npm run seed && npm start",
+    "start-vm": "npm run format && nodemon server.js --vm",
+    "cleanStart-vm": "rm -rf ./node_modules && npm install && npm run seed && npm run start-vm"
   },
   "author": "The GOON Squad",
   "license": "ISC",

--- a/server.js
+++ b/server.js
@@ -5,7 +5,9 @@ const bodyParser = require("body-parser");
 
 // Create backend constants
 const app = express();
-const siteAddress = address.ip();
+const siteAddress = process.argv.includes("--vm")
+  ? "gooncard.hpc.tcnj.edu"
+  : address.ip();
 const port = 3000;
 const viewsPath = __dirname + "/views";
 const sessionKey = "secret";


### PR DESCRIPTION
Closes #138.

This PR includes a tiny change that updates the `server.js`'s web address when running the server on the TCNJ cluster VM. We want to make sure that `gooncard.hpc.tcnj.edu` is being used as the server's address: the IP address for the VM was causing issues. 

Note that the `npm start` and `npm run cleanStart` scripts work fine for local development, but when we want to start the server on the VM, we have to use `npm run start-vm` and `npm run cleanStart-vm` respectively.